### PR TITLE
Add url changes when modal is opened and closed

### DIFF
--- a/components/ContributorLinks.vue
+++ b/components/ContributorLinks.vue
@@ -11,11 +11,11 @@
 
     <a
       v-if="contributor.blog !== ''"
-      class="contributor-links-github"
+      class="contributor-links-blog"
       :href="contributor.blog"
       target="_blank"
     >
-      {{ contributor.blog }}
+      {{ blogText }}
     </a>
   </div>
 </template>
@@ -29,6 +29,17 @@
         required: true,
       }
     },
+    computed: {
+      blogText() {
+        let url = this.contributor.blog.substr(this.contributor.blog.indexOf('://') + 3)
+
+        if(url.length > 22) {
+          url = `${url.substring(0, 22)}...`;
+        }
+
+        return url;
+      }
+    }
   }
 </script>
 

--- a/components/ContributorPopup.vue
+++ b/components/ContributorPopup.vue
@@ -61,7 +61,7 @@
               :key="repository.repositoryName"
             >
               <a
-                :href="`https://github.com/${repository.repositoryName}`"
+                :href="`https://github.com/${repository.repositoryName}/commits?author=${contributor.login}`"
                 target="_blank"
                 class="contributions-item repository"
               >
@@ -137,8 +137,6 @@
     .modal-dialog {
       max-width: 1036px;
       width: 100%;
-      border-radius: 5px;
-      overflow: hidden;
 
       .modal-header {
         border-bottom: 0;
@@ -146,6 +144,8 @@
 
       .modal-content {
         background-color: #f8f8f8;
+        overflow: hidden;
+        border-radius: 5px;
       }
 
       .modal-body {

--- a/components/CopyButton.vue
+++ b/components/CopyButton.vue
@@ -42,7 +42,7 @@
       copyLink() {
         const self = this;
 
-        if(!navigator.clipboard) {
+        if(navigator.clipboard) {
           navigator.clipboard.writeText(this.shareUrl).then(function() {
             self.text = 'Copied!';
 

--- a/components/TopContributors.vue
+++ b/components/TopContributors.vue
@@ -163,7 +163,7 @@
       fetchData() {
         const self = this
         const req = new XMLHttpRequest()
-        req.open('GET', '/static/contributors.js', true)
+        req.open('GET', '/contributors.js', true)
 
         req.onreadystatechange = function () {
           if (req.status >= 200 && req.status < 400 && req.readyState === 4) {
@@ -194,34 +194,35 @@
         const self = this
         const nameParam = self.findAnchor()
 
-        if (nameParam) {
-          self.contributors.forEach((contributor) => {
-            if (contributor.login === nameParam) {
-              if (!contributor.sortedRepositories) {
-                let repositoriesArray = []
-                const tempArray = Object.keys(contributor.repositories)
-                repositoriesArray = tempArray.map((e) => {
-                  repositoriesArray[e] = contributor.repositories[e]
-
-                  return {
-                    number: contributor.repositories[e],
-                    repositoryName: e
-                  }
-                })
-
-                repositoriesArray.sort((a, b) => b.number - a.number)
-
-                contributor.repositories = repositoriesArray
-                contributor.sortedRepositories = true
-              }
-
-              self.selectedContributor = contributor
-              self.$refs['selected-contributor-modal'].show()
-            }
-          })
-        } else {
+        if (!nameParam) {
           self.$refs['selected-contributor-modal'].hide()
+          return
         }
+
+        self.contributors.forEach((contributor) => {
+          if (contributor.login === nameParam) {
+            if (!contributor.sortedRepositories) {
+              let repositoriesArray = []
+              const tempArray = Object.keys(contributor.repositories)
+              repositoriesArray = tempArray.map((e) => {
+                repositoriesArray[e] = contributor.repositories[e]
+
+                return {
+                  number: contributor.repositories[e],
+                  repositoryName: e
+                }
+              })
+
+              repositoriesArray.sort((a, b) => b.number - a.number)
+
+              contributor.repositories = repositoriesArray
+              contributor.sortedRepositories = true
+            }
+
+            self.selectedContributor = contributor
+            self.$refs['selected-contributor-modal'].show()
+          }
+        })
       }
     }
   }

--- a/components/TopContributors.vue
+++ b/components/TopContributors.vue
@@ -39,6 +39,7 @@
       ref="selected-contributor-modal"
       hide-footer
       hide-header
+      @hidden="resetUrl"
     >
       <contributor-popup
         :contributor="selectedContributor"
@@ -140,8 +141,18 @@
 
         if (this.$refs['selected-contributor-modal']) {
           this.$refs['selected-contributor-modal'].show()
+
+          window.history.pushState(
+            this.selectedContributor.login,
+            'PrestaShop Contributors',
+            `/#${this.selectedContributor.login}`
+          )
         }
       })
+
+      window.onpopstate = () => {
+        this.showSelectedContributor()
+      }
     },
     methods: {
       findAnchor() {
@@ -164,32 +175,7 @@
               self.contributors.push(contributor)
             })
 
-            const nameParam = self.findAnchor()
-
-            if (nameParam) {
-              self.contributors.forEach((contributor) => {
-                if (contributor.login === nameParam) {
-                  let repositoriesArray = []
-                  const tempArray = Object.keys(contributor.repositories)
-                  repositoriesArray = tempArray.map((e) => {
-                    repositoriesArray[e] = contributor.repositories[e]
-
-                    return {
-                      number: contributor.repositories[e],
-                      repositoryName: e
-                    }
-                  })
-
-                  repositoriesArray.sort((a, b) => b.number - a.number)
-
-                  contributor.repositories = repositoriesArray
-                  contributor.sortedRepositories = true
-
-                  self.selectedContributor = contributor
-                  self.$refs['selected-contributor-modal'].show()
-                }
-              })
-            }
+            self.showSelectedContributor()
 
             self.loading = false
           }
@@ -199,6 +185,43 @@
       },
       closeModal() {
         this.$refs['selected-contributor-modal'].hide()
+        this.resetUrl()
+      },
+      resetUrl() {
+        window.history.pushState('index', 'PrestaShop Contributors', `/`)
+      },
+      showSelectedContributor() {
+        const self = this
+        const nameParam = self.findAnchor()
+
+        if (nameParam) {
+          self.contributors.forEach((contributor) => {
+            if (contributor.login === nameParam) {
+              if (!contributor.sortedRepositories) {
+                let repositoriesArray = []
+                const tempArray = Object.keys(contributor.repositories)
+                repositoriesArray = tempArray.map((e) => {
+                  repositoriesArray[e] = contributor.repositories[e]
+
+                  return {
+                    number: contributor.repositories[e],
+                    repositoryName: e
+                  }
+                })
+
+                repositoriesArray.sort((a, b) => b.number - a.number)
+
+                contributor.repositories = repositoriesArray
+                contributor.sortedRepositories = true
+              }
+
+              self.selectedContributor = contributor
+              self.$refs['selected-contributor-modal'].show()
+            }
+          })
+        } else {
+          self.$refs['selected-contributor-modal'].hide()
+        }
       }
     }
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This feature aim to change the URL when a modal is opened or closed, in order to provide a full history state and logical to the copy link button, it also contain bugfix on border radius of modal, repo urls are now "search commits" of author urls, personal link is now trimmed as some links were too longs
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
