### PR TITLE
Add pagination to TopCard and show full lists

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -29,7 +29,7 @@ onMounted(async () => {
     const data = await response.json()
 
     companiesData.value = data.companies
-    topCompanies.value = data.companies.slice(0, 5)
+    topCompanies.value = data.companies
     const total: number
       = data.companies.reduce(
         (acc: number, company: Company) => acc + company.merged_pull_requests,
@@ -62,7 +62,7 @@ onMounted(async () => {
       return contributor
     })
     contributorsData.value = contributorsOnly
-    topContributors.value = contributorsOnly.slice(0, 5)
+    topContributors.value = contributorsOnly
   }
   catch (error) {
     console.error('Error loading contributors data:', error)

--- a/app/components/TopCard.vue
+++ b/app/components/TopCard.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { PuikTableHeader } from '@prestashopcorp/puik-components'
+import { PuikPaginationVariants } from '@prestashopcorp/puik-components'
 import type { Company, Contributor } from '@/types'
 
-defineProps<{
+const props = defineProps<{
   title: string
   description?: string
   linkHref?: string
@@ -17,6 +19,43 @@ defineEmits<{
   (e: 'view', item: Company | Contributor): void
   (e: 'action', payload: unknown): void
 }>()
+
+const page = ref(1)
+const itemsPerPage = ref(5)
+const paginationVariant = ref<PuikPaginationVariants>(PuikPaginationVariants.Large)
+
+const paginatedItems = computed(() =>
+  props.items.slice((page.value - 1) * itemsPerPage.value, page.value * itemsPerPage.value),
+)
+
+const updatePaginationVariant = () => {
+  const width = window.innerWidth
+  if (width < 768) {
+    paginationVariant.value = PuikPaginationVariants.Mobile
+  }
+  else if (width < 1024) {
+    paginationVariant.value = PuikPaginationVariants.Medium
+  }
+  else {
+    paginationVariant.value = PuikPaginationVariants.Large
+  }
+}
+
+let mobileMq: MediaQueryList
+let tabletMq: MediaQueryList
+
+onMounted(() => {
+  updatePaginationVariant()
+  mobileMq = window.matchMedia('(max-width: 767px)')
+  tabletMq = window.matchMedia('(min-width: 768px) and (max-width: 1023px)')
+  mobileMq.addEventListener('change', updatePaginationVariant)
+  tabletMq.addEventListener('change', updatePaginationVariant)
+})
+
+onUnmounted(() => {
+  mobileMq?.removeEventListener('change', updatePaginationVariant)
+  tabletMq?.removeEventListener('change', updatePaginationVariant)
+})
 </script>
 
 <template>
@@ -50,7 +89,7 @@ defineEmits<{
     <puik-table
       v-if="items?.length"
       :headers="headers"
-      :items="items"
+      :items="paginatedItems"
       :sticky-last-col="stickyLastCol"
       :full-width="fullWidth"
     >
@@ -67,6 +106,15 @@ defineEmits<{
         </slot>
       </template>
     </puik-table>
+
+    <puik-pagination
+      v-if="items?.length > itemsPerPage"
+      v-model:page="page"
+      v-model:items-per-page="itemsPerPage"
+      :variant="paginationVariant"
+      :total-item="items.length"
+      class="wof-top-card__pagination"
+    />
   </puik-card>
 </template>
 
@@ -95,5 +143,9 @@ defineEmits<{
   .wof-top-card__title {
     font-size: var(--wof-top-card-title-size-sm);
   }
+}
+.wof-top-card__pagination {
+  align-self: center;
+  margin-top: 1rem;
 }
 </style>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Stop slicing top companies/contributors in app.vue and pass full lists to the TopCard component. Implement client-side pagination in TopCard.vue: add page/itemsPerPage state, paginatedItems computed, responsive PuikPaginationVariants selection using matchMedia, mount/unmount listeners, and render a <puik-pagination> control. Also adjust imports and switch to a const props = defineProps(...) so props can be referenced in the script, and add small pagination styling. This enables responsive, client-side paging instead of truncating the data server-side.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
