### PR TITLE
feat: full-population Wall-of-Fame tabs (reviewers/issues/PR) + Top-50 cap

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -121,6 +121,9 @@ onMounted(async () => {
       <WallOfFameSectionView
         :contributors-data="contributorsData"
         :companies-data="companiesData"
+        :reviewers="topReviewers"
+        :issues="topIssues"
+        :pull-requests="topPullRequests"
       />
       <ContributeSectionView
         contribute-link="https://devdocs.prestashop-project.org/9/contribute/contribute-pull-requests/"

--- a/app/components/WallOfFameTable.vue
+++ b/app/components/WallOfFameTable.vue
@@ -2,10 +2,10 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import type { PuikTableHeader, searchOption, sortOption } from '@prestashopcorp/puik-components'
 import { PuikPaginationVariants } from '@prestashopcorp/puik-components'
-import type { Company, Contributor } from '@/types'
+import type { Company, Contributor, RankingEntry } from '@/types'
 
-type TableType = 'contributor' | 'company'
-type TableItem = Contributor | Company
+type TableType = 'contributor' | 'company' | 'ranking'
+type TableItem = Contributor | Company | RankingEntry
 
 const props = defineProps<{
   items: TableItem[]
@@ -141,6 +141,10 @@ const isContributor = (_item: TableItem): _item is Contributor => {
 const isCompany = (_item: TableItem): _item is Company => {
   return props.type === 'company'
 }
+
+const isRanking = (item: TableItem): item is RankingEntry => {
+  return props.type === 'ranking' && 'count' in item
+}
 </script>
 
 <template>
@@ -226,6 +230,32 @@ const isCompany = (_item: TableItem): _item is Company => {
             </span>
           </div>
         </div>
+
+        <!-- Ranking display -->
+        <div
+          v-else-if="isRanking(item)"
+          class="wof-contributors__login__container"
+        >
+          <puik-avatar
+            size="large"
+            type="photo"
+            :src="item.avatar_url"
+          />
+          <div class="wof-top-contributors__name">
+            <span class="puik-body-default">{{ item.name || item.login }}</span>
+            <span
+              v-if="item.name"
+              class="puik-body-small-bold"
+            >({{ item.login }})</span>
+          </div>
+        </div>
+      </template>
+
+      <template #item-count="{ item }">
+        <span
+          v-if="isRanking(item)"
+          class="puik-body-default-bold"
+        >{{ item.count }}</span>
       </template>
 
       <template #item-actions="{ item }">
@@ -239,9 +269,9 @@ const isCompany = (_item: TableItem): _item is Company => {
           @click="handleActionClick(item)"
         />
 
-        <!-- Company actions: link to GitHub -->
+        <!-- Company / ranking actions: link to GitHub -->
         <a
-          v-else-if="type === 'company'"
+          v-else-if="type === 'company' || type === 'ranking'"
           :href="item.html_url"
           target="_blank"
           aria-label="view profile"
@@ -261,7 +291,7 @@ const isCompany = (_item: TableItem): _item is Company => {
       v-if="itemsRef.length === 0"
       class="wof-no-results"
     >
-      No {{ type === 'contributor' ? 'contributors' : 'companies' }} found with your search.
+      No results found with your search.
     </div>
 
     <puik-pagination

--- a/app/components/sections/TopSectionView.vue
+++ b/app/components/sections/TopSectionView.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Contributor, Company, RankingEntry } from '@/types'
 
-defineProps<{
+const props = defineProps<{
   topContributors: Contributor[]
   topCompanies: Company[]
   topReviewers: RankingEntry[]
   topIssues: RankingEntry[]
   topPullRequests: RankingEntry[]
 }>()
+
+const TOP_DISPLAY = 50
+const topReviewersCapped = computed(() => props.topReviewers.slice(0, TOP_DISPLAY))
+const topIssuesCapped = computed(() => props.topIssues.slice(0, TOP_DISPLAY))
+const topPullRequestsCapped = computed(() => props.topPullRequests.slice(0, TOP_DISPLAY))
 </script>
 
 <template>
@@ -19,25 +25,25 @@ defineProps<{
       <TopCompaniesView :top-companies="topCompanies" />
       <TopContributorsView :top-contributors="topContributors" />
       <TopRankingView
-        v-if="topReviewers.length"
+        v-if="topReviewersCapped.length"
         title="👀 Top reviewers"
         description="They review pull requests to keep PrestaShop's quality high."
         count-label="Reviews"
-        :items="topReviewers"
+        :items="topReviewersCapped"
       />
       <TopRankingView
-        v-if="topIssues.length"
+        v-if="topIssuesCapped.length"
         title="🐛 Top issue reporters"
         description="They report issues that help us improve PrestaShop."
         count-label="Issues"
-        :items="topIssues"
+        :items="topIssuesCapped"
       />
       <TopRankingView
-        v-if="topPullRequests.length"
+        v-if="topPullRequestsCapped.length"
         title="🔀 Top PR authors"
         description="They open pull requests to move PrestaShop forward."
         count-label="Pull requests"
-        :items="topPullRequests"
+        :items="topPullRequestsCapped"
       />
     </div>
   </section>

--- a/app/components/sections/WallOfFameSectionView.vue
+++ b/app/components/sections/WallOfFameSectionView.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { PuikTableHeader } from '@prestashopcorp/puik-components'
-import type { Company, Contributor } from '@/types'
+import type { Company, Contributor, RankingEntry } from '@/types'
 
 type TableItem = Contributor | Company
 
 const props = defineProps<{
   contributorsData: Contributor[]
   companiesData: Company[]
+  reviewers: RankingEntry[]
+  issues: RankingEntry[]
+  pullRequests: RankingEntry[]
 }>()
 
 // CONTRIBUTORS TABLE CONFIG
@@ -58,6 +61,13 @@ const companiesHeaders: PuikTableHeader[] = [
   { value: 'actions', size: 'sm', align: 'center', preventExpand: true, searchSubmit: true },
 ]
 
+const rankingHeaders = (countLabel: string): PuikTableHeader[] => [
+  { text: 'Rank', value: 'rank', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { text: 'Name', value: 'name', size: 'lg', align: 'left', searchable: true, sortable: true },
+  { text: countLabel, value: 'count', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { value: 'actions', size: 'sm', align: 'center', preventExpand: true, searchSubmit: true },
+]
+
 const contributorsRef = computed(() => props.contributorsData)
 
 const { currentContributor, isModalOpen, openModal, closeModal }
@@ -98,6 +108,15 @@ const handleContributorAction = (item: TableItem) => {
         <puik-tab-navigation-title :position="2">
           Companies
         </puik-tab-navigation-title>
+        <puik-tab-navigation-title :position="3">
+          Reviewers
+        </puik-tab-navigation-title>
+        <puik-tab-navigation-title :position="4">
+          Issue reporters
+        </puik-tab-navigation-title>
+        <puik-tab-navigation-title :position="5">
+          PR authors
+        </puik-tab-navigation-title>
       </puik-tab-navigation-group-titles>
       <puik-tab-navigation-group-panels>
         <puik-tab-navigation-panel :position="1">
@@ -119,6 +138,27 @@ const handleContributorAction = (item: TableItem) => {
             :items="companiesData"
             :headers="companiesHeaders"
             type="company"
+          />
+        </puik-tab-navigation-panel>
+        <puik-tab-navigation-panel :position="3">
+          <WallOfFameTable
+            :items="reviewers"
+            :headers="rankingHeaders('Reviews')"
+            type="ranking"
+          />
+        </puik-tab-navigation-panel>
+        <puik-tab-navigation-panel :position="4">
+          <WallOfFameTable
+            :items="issues"
+            :headers="rankingHeaders('Issues')"
+            type="ranking"
+          />
+        </puik-tab-navigation-panel>
+        <puik-tab-navigation-panel :position="5">
+          <WallOfFameTable
+            :items="pullRequests"
+            :headers="rankingHeaders('Pull requests')"
+            type="ranking"
           />
         </puik-tab-navigation-panel>
       </puik-tab-navigation-group-panels>

--- a/test/nuxt/TopSectionView.test.ts
+++ b/test/nuxt/TopSectionView.test.ts
@@ -39,4 +39,21 @@ describe('TopSectionView', () => {
     expect(text).not.toContain('Top issue reporters')
     expect(text).not.toContain('Top PR authors')
   })
+
+  it('caps each new leaderboard at 50 entries', async () => {
+    const many = (login: string): RankingEntry[] =>
+      Array.from({ length: 60 }, (_, i) => ({
+        rank: i + 1, login: `${login}${i}`, name: `${login}${i}`,
+        avatar_url: 'https://a/1.png', html_url: `https://github.com/${login}${i}`, count: 60 - i,
+      }))
+    const component = await mountSuspended(TopSectionView, {
+      props: {
+        topContributors: [], topCompanies: [],
+        topReviewers: many('rev'), topIssues: many('iss'), topPullRequests: many('pr'),
+      },
+    })
+    // TopCard shows "<total> result(s)" from the items length; capped list = 50, not 60
+    expect(component.text()).toContain('50 result(s)')
+    expect(component.text()).not.toContain('60 result(s)')
+  })
 })

--- a/test/nuxt/WallOfFameRanking.test.ts
+++ b/test/nuxt/WallOfFameRanking.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import type { PuikTableHeader } from '@prestashopcorp/puik-components'
+import WallOfFameTable from '@/components/WallOfFameTable.vue'
+import type { RankingEntry } from '@/types'
+
+const headers: PuikTableHeader[] = [
+  { text: 'Rank', value: 'rank', size: 'sm', align: 'center' },
+  { text: 'Name', value: 'name', size: 'lg', align: 'left' },
+  { text: 'Reviews', value: 'count', size: 'sm', align: 'center' },
+  { value: 'actions', size: 'sm', align: 'center' },
+]
+const items: RankingEntry[] = [
+  { rank: 1, login: 'alice', name: 'Alice', avatar_url: 'https://a/1.png', html_url: 'https://github.com/alice', count: 312 },
+]
+
+describe('WallOfFameTable (ranking)', () => {
+  it('renders a ranking row with count and GitHub link', async () => {
+    const component = await mountSuspended(WallOfFameTable, {
+      props: { items, headers, type: 'ranking' },
+    })
+    const text = component.text()
+    expect(text).toContain('Alice')
+    expect(text).toContain('312')
+    const hrefs = component.findAll('a').map(a => a.attributes('href'))
+    expect(hrefs).toContain('https://github.com/alice')
+  })
+})

--- a/test/nuxt/WallOfFameSectionView.test.ts
+++ b/test/nuxt/WallOfFameSectionView.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import WallOfFameSectionView from '@/components/sections/WallOfFameSectionView.vue'
+import type { RankingEntry } from '@/types'
+
+const ranking = (login: string): RankingEntry[] => [
+  { rank: 1, login, name: login, avatar_url: 'https://a/1.png', html_url: `https://github.com/${login}`, count: 7 },
+]
+
+describe('WallOfFameSectionView', () => {
+  // Note: puik-tab-navigation only renders the active tab's panel, so the
+  // ranking tables (positions 3-5) are not mounted until their tab is opened —
+  // asserting their content at the section level is impractical here. The
+  // table rendering itself is covered by WallOfFameRanking.test.ts; this test
+  // guards that the three ranking tabs are registered.
+  it('renders the three new ranking tab titles', async () => {
+    const component = await mountSuspended(WallOfFameSectionView, {
+      props: {
+        contributorsData: [],
+        companiesData: [],
+        reviewers: ranking('rev'),
+        issues: ranking('iss'),
+        pullRequests: ranking('pr'),
+      },
+    })
+    const text = component.text()
+    expect(text).toContain('Reviewers')
+    expect(text).toContain('Issue reporters')
+    expect(text).toContain('PR authors')
+  })
+})


### PR DESCRIPTION
Follow-up to #231. Broadens the reviews/issues/PR leaderboards to the **full population** instead of only the top of each list.

## Summary
- **Wall of Fame** gains three tabs — **Reviewers**, **Issue reporters**, **PR authors** — listing everyone (committers *and* non-committers), searchable / sortable / paginated like the existing tabs. New `type="ranking"` on `WallOfFameTable` (avatar + name + login, count column, GitHub link, no modal).
- Homepage **Top** section stays a curated highlight, now **capped at 50** per leaderboard (`slice(0, 50)`); the full lists feed the Wall of Fame from the same `app.vue` refs.
- Same `RankingEntry` contract — the data side just emits more entries.

## Dependency
Needs the Traces change that emits the full lists with identity resolved at fetch time (no per-user API call): PrestaShop/traces#233. Once released and the scheduled *Build & Deploy* runs, the tabs populate with real full-population data.

## Test Plan
- [x] `vitest run` — 9/9 green (ranking table, WoF tabs registered, Top-50 cap, empty-hide)
- [x] `eslint .` — clean
- [ ] Visual check once traces#233 is released and data regenerates

🤖 Generated with [Claude Code](https://claude.com/claude-code)