### PR TITLE
feat: remove the 50-item cap on the Top reviewers/issues/PR sections

### DIFF
--- a/app/components/sections/TopSectionView.vue
+++ b/app/components/sections/TopSectionView.vue
@@ -1,19 +1,13 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { Contributor, Company, RankingEntry } from '@/types'
 
-const props = defineProps<{
+defineProps<{
   topContributors: Contributor[]
   topCompanies: Company[]
   topReviewers: RankingEntry[]
   topIssues: RankingEntry[]
   topPullRequests: RankingEntry[]
 }>()
-
-const TOP_DISPLAY = 50
-const topReviewersCapped = computed(() => props.topReviewers.slice(0, TOP_DISPLAY))
-const topIssuesCapped = computed(() => props.topIssues.slice(0, TOP_DISPLAY))
-const topPullRequestsCapped = computed(() => props.topPullRequests.slice(0, TOP_DISPLAY))
 </script>
 
 <template>
@@ -25,25 +19,25 @@ const topPullRequestsCapped = computed(() => props.topPullRequests.slice(0, TOP_
       <TopCompaniesView :top-companies="topCompanies" />
       <TopContributorsView :top-contributors="topContributors" />
       <TopRankingView
-        v-if="topReviewersCapped.length"
+        v-if="topReviewers.length"
         title="👀 Top reviewers"
         description="They review pull requests to keep PrestaShop's quality high."
         count-label="Reviews"
-        :items="topReviewersCapped"
+        :items="topReviewers"
       />
       <TopRankingView
-        v-if="topIssuesCapped.length"
+        v-if="topIssues.length"
         title="🐛 Top issue reporters"
         description="They report issues that help us improve PrestaShop."
         count-label="Issues"
-        :items="topIssuesCapped"
+        :items="topIssues"
       />
       <TopRankingView
-        v-if="topPullRequestsCapped.length"
+        v-if="topPullRequests.length"
         title="🔀 Top PR authors"
         description="They open pull requests to move PrestaShop forward."
         count-label="Pull requests"
-        :items="topPullRequestsCapped"
+        :items="topPullRequests"
       />
     </div>
   </section>

--- a/test/nuxt/TopSectionView.test.ts
+++ b/test/nuxt/TopSectionView.test.ts
@@ -40,7 +40,7 @@ describe('TopSectionView', () => {
     expect(text).not.toContain('Top PR authors')
   })
 
-  it('caps each new leaderboard at 50 entries', async () => {
+  it('lists every entry (no cap), like the other Top tables', async () => {
     const many = (login: string): RankingEntry[] =>
       Array.from({ length: 60 }, (_, i) => ({
         rank: i + 1, login: `${login}${i}`, name: `${login}${i}`,
@@ -52,8 +52,8 @@ describe('TopSectionView', () => {
         topReviewers: many('rev'), topIssues: many('iss'), topPullRequests: many('pr'),
       },
     })
-    // TopCard shows "<total> result(s)" from the items length; capped list = 50, not 60
-    expect(component.text()).toContain('50 result(s)')
-    expect(component.text()).not.toContain('60 result(s)')
+    // TopCard shows "<total> result(s)" from the items length — the full 60, not a capped subset
+    expect(component.text()).toContain('60 result(s)')
+    expect(component.text()).not.toContain('50 result(s)')
   })
 })


### PR DESCRIPTION
Per review feedback (Franck Lefevre): drop the 50-item limit on the Top reviewers / issue reporters / PR authors sections so they behave like the existing **Top contributors** / **Top companies** tables — full list, paginated.

## Change
- `TopSectionView`: the three ranking cards now receive the full `topReviewers` / `topIssues` / `topPullRequests` lists directly (removed the `slice(0, 50)` computeds).
- No data/payload change — the full lists were already loaded (they also feed the Wall of Fame tabs).

## Test Plan
- [x] `vitest run` — 9/9 green (updated the cap test to assert the full list is shown, no cap)
- [x] `eslint .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)