### PR TITLE
feat(ui): Top security researchers ranking

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -107,6 +107,16 @@ jobs:
         working-directory: ./traces
         run: php bin/console traces:generate:topstats --ghtoken=${ENV_USER_PASS} --config="./config.dist.yml"
 
+      - name: Fetch security advisories 🔧
+        if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
+        working-directory: ./traces
+        run: php bin/console traces:fetch:security-advisories --ghtoken=${ENV_USER_PASS}
+
+      - name: Generate top security 🔧
+        if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
+        working-directory: ./traces
+        run: php bin/console traces:generate:topsecurity --ghtoken=${ENV_USER_PASS} --config="./config.dist.yml"
+
       - name: Display Contributors without Companies 🔎
         if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
         run: cat ./traces/gh_loginsWOCompany.json
@@ -122,6 +132,7 @@ jobs:
           mv ./traces/top_reviewers.json ./dist
           mv ./traces/top_issues.json ./dist
           mv ./traces/top_pullrequests.json ./dist
+          mv ./traces/top_security.json ./dist
 
       - name: Write CNAME file 🌐
         run: echo 'contributors.prestashop-project.org' > ./dist/CNAME

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ public/topcompanies_prs.json
 public/top_reviewers.json
 public/top_issues.json
 public/top_pullrequests.json
+public/top_security.json

--- a/app/app.vue
+++ b/app/app.vue
@@ -14,6 +14,7 @@ const newContributors = ref<NewContributor[]>([])
 const topReviewers = ref<RankingEntry[]>([])
 const topIssues = ref<RankingEntry[]>([])
 const topPullRequests = ref<RankingEntry[]>([])
+const topSecurity = ref<RankingEntry[]>([])
 
 onMounted(async () => {
   try {
@@ -100,6 +101,16 @@ onMounted(async () => {
   catch (error) {
     console.error('Error loading top pull requests:', error)
   }
+
+  try {
+    const response = await fetch('/top_security.json')
+    if (!response.ok) throw new Error('Error loading top security')
+    const data = await response.json()
+    topSecurity.value = data.items ?? []
+  }
+  catch (error) {
+    console.error('Error loading top security:', error)
+  }
 })
 </script>
 
@@ -116,6 +127,7 @@ onMounted(async () => {
         :top-reviewers="topReviewers"
         :top-issues="topIssues"
         :top-pull-requests="topPullRequests"
+        :top-security="topSecurity"
       />
       <NewContributorsSectionView :new-contributors="newContributors" />
       <WallOfFameSectionView
@@ -124,6 +136,7 @@ onMounted(async () => {
         :reviewers="topReviewers"
         :issues="topIssues"
         :pull-requests="topPullRequests"
+        :security="topSecurity"
       />
       <ContributeSectionView
         contribute-link="https://devdocs.prestashop-project.org/9/contribute/contribute-pull-requests/"

--- a/app/components/sections/TopSectionView.vue
+++ b/app/components/sections/TopSectionView.vue
@@ -7,6 +7,7 @@ defineProps<{
   topReviewers: RankingEntry[]
   topIssues: RankingEntry[]
   topPullRequests: RankingEntry[]
+  topSecurity: RankingEntry[]
 }>()
 </script>
 
@@ -38,6 +39,13 @@ defineProps<{
         description="They open pull requests to move PrestaShop forward."
         count-label="Pull requests"
         :items="topPullRequests"
+      />
+      <TopRankingView
+        v-if="topSecurity.length"
+        title="🛡️ Top security researchers"
+        description="They find and report the vulnerabilities disclosed in security advisories."
+        count-label="Advisories"
+        :items="topSecurity"
       />
     </div>
   </section>

--- a/app/components/sections/WallOfFameSectionView.vue
+++ b/app/components/sections/WallOfFameSectionView.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
   reviewers: RankingEntry[]
   issues: RankingEntry[]
   pullRequests: RankingEntry[]
+  security: RankingEntry[]
 }>()
 
 // CONTRIBUTORS TABLE CONFIG
@@ -117,6 +118,12 @@ const handleContributorAction = (item: TableItem) => {
         <puik-tab-navigation-title :position="5">
           PR authors
         </puik-tab-navigation-title>
+        <puik-tab-navigation-title
+          v-if="security.length"
+          :position="6"
+        >
+          Security
+        </puik-tab-navigation-title>
       </puik-tab-navigation-group-titles>
       <puik-tab-navigation-group-panels>
         <puik-tab-navigation-panel :position="1">
@@ -158,6 +165,16 @@ const handleContributorAction = (item: TableItem) => {
           <WallOfFameTable
             :items="pullRequests"
             :headers="rankingHeaders('Pull requests')"
+            type="ranking"
+          />
+        </puik-tab-navigation-panel>
+        <puik-tab-navigation-panel
+          v-if="security.length"
+          :position="6"
+        >
+          <WallOfFameTable
+            :items="security"
+            :headers="rankingHeaders('Advisories')"
             type="ranking"
           />
         </puik-tab-navigation-panel>

--- a/test/nuxt/TopSectionView.test.ts
+++ b/test/nuxt/TopSectionView.test.ts
@@ -8,7 +8,7 @@ const ranking = (login: string): RankingEntry[] => [
 ]
 
 describe('TopSectionView', () => {
-  it('renders the three new leaderboard titles', async () => {
+  it('renders the four new leaderboard titles', async () => {
     const component = await mountSuspended(TopSectionView, {
       props: {
         topContributors: [],
@@ -16,12 +16,14 @@ describe('TopSectionView', () => {
         topReviewers: ranking('rev'),
         topIssues: ranking('iss'),
         topPullRequests: ranking('pr'),
+        topSecurity: ranking('sec'),
       },
     })
     const text = component.text()
     expect(text).toContain('Top reviewers')
     expect(text).toContain('Top issue reporters')
     expect(text).toContain('Top PR authors')
+    expect(text).toContain('Top security researchers')
   })
 
   it('hides a leaderboard whose ranking is empty', async () => {
@@ -32,12 +34,14 @@ describe('TopSectionView', () => {
         topReviewers: [],
         topIssues: [],
         topPullRequests: [],
+        topSecurity: [],
       },
     })
     const text = component.text()
     expect(text).not.toContain('Top reviewers')
     expect(text).not.toContain('Top issue reporters')
     expect(text).not.toContain('Top PR authors')
+    expect(text).not.toContain('Top security researchers')
   })
 
   it('lists every entry (no cap), like the other Top tables', async () => {
@@ -50,6 +54,7 @@ describe('TopSectionView', () => {
       props: {
         topContributors: [], topCompanies: [],
         topReviewers: many('rev'), topIssues: many('iss'), topPullRequests: many('pr'),
+        topSecurity: many('sec'),
       },
     })
     // TopCard shows "<total> result(s)" from the items length — the full 60, not a capped subset

--- a/test/nuxt/WallOfFameSectionView.test.ts
+++ b/test/nuxt/WallOfFameSectionView.test.ts
@@ -13,7 +13,7 @@ describe('WallOfFameSectionView', () => {
   // asserting their content at the section level is impractical here. The
   // table rendering itself is covered by WallOfFameRanking.test.ts; this test
   // guards that the three ranking tabs are registered.
-  it('renders the three new ranking tab titles', async () => {
+  it('renders the four new ranking tab titles', async () => {
     const component = await mountSuspended(WallOfFameSectionView, {
       props: {
         contributorsData: [],
@@ -21,11 +21,27 @@ describe('WallOfFameSectionView', () => {
         reviewers: ranking('rev'),
         issues: ranking('iss'),
         pullRequests: ranking('pr'),
+        security: ranking('sec'),
       },
     })
     const text = component.text()
     expect(text).toContain('Reviewers')
     expect(text).toContain('Issue reporters')
     expect(text).toContain('PR authors')
+    expect(text).toContain('Security')
+  })
+
+  it('hides the Security tab when no advisory data is available', async () => {
+    const component = await mountSuspended(WallOfFameSectionView, {
+      props: {
+        contributorsData: [],
+        companiesData: [],
+        reviewers: ranking('rev'),
+        issues: ranking('iss'),
+        pullRequests: ranking('pr'),
+        security: [],
+      },
+    })
+    expect(component.text()).not.toContain('Security')
   })
 })


### PR DESCRIPTION
## Why

Security researchers who find and report vulnerabilities never appear on the site today: fixes go through a private security repo and are republished by the core team, so the original reporter is lost from the PR/commit history. This surfaces them from the GitHub security-advisory credits instead.

## What this does

- New **"🛡️ Top security researchers"** card in the Top section.
- New **"Security"** tab in the Wall of Fame.

Both are fed by `top_security.json` (produced by the companion `traces` commands) and reuse the existing ranking table — same `Rank / Name / Advisories` layout as the reviewers / issues / PR rankings. The card and tab are hidden automatically when the data file is absent, so nothing breaks if the JSON isn't there yet.

The ranking counts **research credits only** (finder / reporter / analyst) — remediation credits go to core developers already counted in the other leaderboards. See the companion traces PR for the rationale.

## Pipeline

`.github/workflows/gh-pages.yml` gets two new steps (fetch + generate) and publishes `top_security.json` alongside the other data files.

## ⚠️ Merge order

This depends on the traces PR: PrestaShop/traces#235. The `mv top_security.json` step here will fail until a **traces release** that includes those commands is published. Suggested order:

1. Merge the traces PR
2. Publish a traces release tag
3. Merge this PR

## Checks

- ESLint clean.
- `vitest` green (10/10), including updated coverage for the new card and tab.
- Rendering verified in the dev server: the Security tab lists the credited researchers with their advisory counts.

## ⚠️ Known limitation (process, not code)

No PrestaShop advisory published since ~May 2024 has its credits filled in, so the ranking currently shows mostly 2020–2024 history and will stay sparse until credits are entered going forward. Credits are retro-editable on published advisories — filling them is a security-team process topic, not a code change here. This feature is meant to be the concrete argument for making that part of the advisory workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
