### PR TITLE
feat(ui): split security ranking into research + fix credits

### DIFF
--- a/app/components/sections/TopSectionView.vue
+++ b/app/components/sections/TopSectionView.vue
@@ -42,10 +42,14 @@ defineProps<{
       />
       <TopRankingView
         v-if="topSecurity.length"
-        title="🛡️ Top security researchers"
-        description="They find and report the vulnerabilities disclosed in security advisories."
+        title="🛡️ Top security contributors"
+        description="They are credited on published security advisories — reporting the vulnerability or shipping the fix."
         count-label="Advisories"
         :items="topSecurity"
+        :extra-columns="[
+          { label: 'Research', value: 'research' },
+          { label: 'Fixes', value: 'remediation' },
+        ]"
       />
     </div>
   </section>

--- a/app/components/sections/WallOfFameSectionView.vue
+++ b/app/components/sections/WallOfFameSectionView.vue
@@ -69,6 +69,18 @@ const rankingHeaders = (countLabel: string): PuikTableHeader[] => [
   { value: 'actions', size: 'sm', align: 'center', preventExpand: true, searchSubmit: true },
 ]
 
+// SECURITY TABLE CONFIG — Advisories is the total (sorted), then split
+// between research credits (finder / reporter / analyst) and remediation
+// credits (developer / reviewer / verifier).
+const securityHeaders: PuikTableHeader[] = [
+  { text: 'Rank', value: 'rank', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { text: 'Name', value: 'name', size: 'lg', align: 'left', searchable: true, sortable: true },
+  { text: 'Advisories', value: 'count', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { text: 'Research', value: 'research', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { text: 'Fixes', value: 'remediation', size: 'sm', align: 'center', searchable: true, searchType: 'range', sortable: true },
+  { value: 'actions', size: 'sm', align: 'center', preventExpand: true, searchSubmit: true },
+]
+
 const contributorsRef = computed(() => props.contributorsData)
 
 const { currentContributor, isModalOpen, openModal, closeModal }
@@ -174,7 +186,7 @@ const handleContributorAction = (item: TableItem) => {
         >
           <WallOfFameTable
             :items="security"
-            :headers="rankingHeaders('Advisories')"
+            :headers="securityHeaders"
             type="ranking"
           />
         </puik-tab-navigation-panel>

--- a/app/components/sections/sub-sections/TopRankingView.vue
+++ b/app/components/sections/sub-sections/TopRankingView.vue
@@ -8,6 +8,10 @@ const props = defineProps<{
   description: string
   countLabel: string
   items: RankingEntry[]
+  // Optional breakdown columns rendered between the total and the actions
+  // cell. Their values come from RankingEntry's extra numeric fields (e.g.
+  // `research`, `remediation` for the security ranking).
+  extraColumns?: { label: string, value: string }[]
 }>()
 
 const headers: PuikTableHeader[] = [
@@ -15,6 +19,7 @@ const headers: PuikTableHeader[] = [
   { text: 'Avatar', value: 'avatar', size: 'sm', align: 'center', searchable: false },
   { text: 'Name', value: 'name', size: 'md', align: 'left', searchable: true },
   { text: props.countLabel, value: 'count', size: 'sm', align: 'center', searchable: false },
+  ...(props.extraColumns ?? []).map(c => ({ text: c.label, value: c.value, size: 'sm' as const, align: 'center' as const, searchable: false })),
   { value: 'actions', size: 'sm', align: 'center', preventExpand: true, searchSubmit: true },
 ]
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -53,6 +53,11 @@ export interface RankingEntry {
   avatar_url: string
   html_url: string
   count: number
+  // Security ranking only: per-advisory credits split between research
+  // (finder / reporter / analyst) and remediation (developer / reviewer /
+  // verifier). `count` is the sum of both.
+  research?: number
+  remediation?: number
 }
 
 export interface Ranking {

--- a/test/nuxt/TopRankingView.test.ts
+++ b/test/nuxt/TopRankingView.test.ts
@@ -37,4 +37,26 @@ describe('TopRankingView', () => {
     expect(component.find('.wof-top-section__rank--first').exists()).toBe(true)
     expect(component.find('.wof-top-section__rank--second').exists()).toBe(true)
   })
+
+  it('renders extra numeric columns (research / remediation) when provided', async () => {
+    const securityItems: RankingEntry[] = [
+      { rank: 1, login: 'carol', name: 'Carol', avatar_url: 'https://a/3.png', html_url: 'https://github.com/carol', count: 9, research: 6, remediation: 3 },
+    ]
+    const component = await mountSuspended(TopRankingView, {
+      props: {
+        title: '🛡️ Top security contributors', description: 'd', countLabel: 'Advisories',
+        items: securityItems,
+        extraColumns: [
+          { label: 'Research', value: 'research' },
+          { label: 'Fixes', value: 'remediation' },
+        ],
+      },
+    })
+    const text = component.text()
+    expect(text).toContain('Research')
+    expect(text).toContain('Fixes')
+    expect(text).toContain('9')
+    expect(text).toContain('6')
+    expect(text).toContain('3')
+  })
 })

--- a/test/nuxt/TopSectionView.test.ts
+++ b/test/nuxt/TopSectionView.test.ts
@@ -23,7 +23,7 @@ describe('TopSectionView', () => {
     expect(text).toContain('Top reviewers')
     expect(text).toContain('Top issue reporters')
     expect(text).toContain('Top PR authors')
-    expect(text).toContain('Top security researchers')
+    expect(text).toContain('Top security contributors')
   })
 
   it('hides a leaderboard whose ranking is empty', async () => {
@@ -41,7 +41,7 @@ describe('TopSectionView', () => {
     expect(text).not.toContain('Top reviewers')
     expect(text).not.toContain('Top issue reporters')
     expect(text).not.toContain('Top PR authors')
-    expect(text).not.toContain('Top security researchers')
+    expect(text).not.toContain('Top security contributors')
   })
 
   it('lists every entry (no cap), like the other Top tables', async () => {

--- a/test/nuxt/WallOfFameRanking.test.ts
+++ b/test/nuxt/WallOfFameRanking.test.ts
@@ -25,4 +25,24 @@ describe('WallOfFameTable (ranking)', () => {
     const hrefs = component.findAll('a').map(a => a.attributes('href'))
     expect(hrefs).toContain('https://github.com/alice')
   })
+
+  it('renders the security research and remediation counts via default cells', async () => {
+    const securityHeaders: PuikTableHeader[] = [
+      ...headers.slice(0, 3),
+      { text: 'Research', value: 'research', size: 'sm', align: 'center' },
+      { text: 'Fixes', value: 'remediation', size: 'sm', align: 'center' },
+      headers[3]!,
+    ]
+    const securityItems: RankingEntry[] = [
+      { rank: 1, login: 'carol', name: 'Carol', avatar_url: 'https://a/2.png', html_url: 'https://github.com/carol', count: 9, research: 6, remediation: 3 },
+    ]
+    const component = await mountSuspended(WallOfFameTable, {
+      props: { items: securityItems, headers: securityHeaders, type: 'ranking' },
+    })
+    const text = component.text()
+    expect(text).toContain('Carol')
+    expect(text).toContain('9')
+    expect(text).toContain('6')
+    expect(text).toContain('3')
+  })
 })


### PR DESCRIPTION
## Why

Follow-up to #237. After discussion with the security team, the split between the two kinds of credited work is worth showing everywhere, not only in the Wall of Fame — because that's the whole point of the board:

- The people who **find and report** vulnerabilities show up on public GitHub anyway (advisory pages, sometimes their own writeups); it's decent recognition.
- The people who **ship the fix** push their commits through the **private security repository**, then their patches are republished by the core team on the public repo — so they never appear as author on any public PR or commit. Their work is invisible everywhere else in the Top Contributors site. This board is essentially the only place it surfaces.

Hiding that behind a single total defeats the purpose. Both views now show the breakdown.

## What this does

Both the compact **Top card** in the Top section and the **Wall of Fame Security tab** now display three numeric columns:

**Advisories · Research · Fixes**

- **Advisories** — total credited advisories (sort key, unchanged).
- **Research** — advisories where the person holds a `finder` / `reporter` / `analyst` / `coordinator` credit.
- **Fixes** — advisories where the person holds a `remediation_developer` / `reviewer` / `verifier` credit.

Fed by the new `research` and `remediation` fields on `top_security.json`. `TopRankingView` gets an optional `extraColumns` prop so the other cards (Reviewers / Issues / PR authors) stay single-column and untouched.

Card title stays neutral (**"🛡️ Top security contributors"**) — the split does the talking.

## ⚠️ Merge order

Depends on the traces PR: PrestaShop/traces#236. The `top_security.json` published by the current traces release (v6.4.0) only carries `count`; the front columns will render `-` until a **new traces release** is published including #236. Suggested order:

1. Merge PrestaShop/traces#236
2. Publish a traces release tag
3. Merge this PR

## Checks

- ESLint clean.
- `vitest` green (12/12), including new coverage for the extra-columns rendering.
- Verified in the dev server: card and tab both show Advisories / Research / Fixes with correct per-family counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
