### PR TITLE
fix(period): widen fallback-banner detection to avoid false positives

### DIFF
--- a/app/pages/company/[slug].vue
+++ b/app/pages/company/[slug].vue
@@ -33,7 +33,12 @@ watchEffect(async () => {
 
 const vm = useEntityDetail(company, period, updatedYear)
 const yearsActive = computed(() => Object.keys(vm.value?.yearlySeries.mergedPullRequests ?? {}).length)
-const isLegacyData = computed(() => company.value?.merged_pull_requests_by_year === undefined)
+const isLegacyData = computed(() => {
+  const c = company.value
+  if (!c) return false
+  return c.merged_pull_requests_by_year === undefined
+    && c.contributions_by_year === undefined
+})
 
 useHead(() => ({
   title: company.value?.name || 'Company',

--- a/app/pages/contributor/[login].vue
+++ b/app/pages/contributor/[login].vue
@@ -45,7 +45,17 @@ watchEffect(async () => {
 
 const vm = useEntityDetail(contributor, period, updatedYear)
 const yearsActive = computed(() => Object.keys(vm.value?.yearlySeries.mergedPullRequests ?? {}).length)
-const isLegacyData = computed(() => contributor.value?.mergedPullRequestsByYear === undefined)
+const isLegacyData = computed(() => {
+  const c = contributor.value
+  if (!c) return false
+  // Fresh data if ANY tracked dimension carries a byYear map. A contributor
+  // with zero activity in one dimension may lack that specific map, so we
+  // check them all rather than picking one arbitrarily.
+  return c.mergedPullRequestsByYear === undefined
+    && c.pullRequestsOpenedByYear === undefined
+    && c.reviewsByYear === undefined
+    && c.issuesOpenedByYear === undefined
+})
 
 useHead(() => ({
   title: contributor.value?.name || contributor.value?.login || 'Contributor',

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -33,8 +33,16 @@ const totalMergedPr = computed<number>(() => {
 })
 
 const isLegacyData = computed(() => {
-  const sample = contributorsData.value.slice(0, 3)
-  return sample.length > 0 && sample.every(c => c.mergedPullRequestsByYear === undefined)
+  // Fresh data is signalled by ANY contributor exposing a byYear sibling map
+  // (or the aggregated community counter carrying one). Contributors with zero
+  // merged PRs legitimately lack the map, so a small sample can produce false
+  // positives — hence the wide sample plus the community fallback.
+  const sample = contributorsData.value.slice(0, 50)
+  if (!sample.length) return false
+  if (sample.some(c => c.mergedPullRequestsByYear !== undefined)) return false
+  const community = communityCounter.value
+  if (community && typeof community !== 'number' && community.byYear) return false
+  return true
 })
 
 const prestaMergedPrbyPercent = computed<number>(() => {


### PR DESCRIPTION
## Summary

Follow-up to #241 (merged). The period-fallback banner is firing on fresh (byYear-enabled) traces snapshots because the previous heuristic sampled only the first 3 contributors and treated 'no byYear map' as legacy. Contributors with zero merged PRs legitimately lack that map, so a small sample can produce false positives.

## Fix

- **Landing** (`pages/index.vue`): sample widened to 50 contributors, plus a fallback on the community counter's byYear presence.
- **Contributor detail** (`pages/contributor/[login].vue`): checks all four tracked dimensions (merged PRs / opened PRs / reviews / issues) rather than just one, so a contributor without opened PRs (for example) doesn't trigger the banner alone.
- **Company detail** (`pages/company/[slug].vue`): checks both \`merged_pull_requests_by_year\` AND \`contributions_by_year\`.

The banner still fires on genuinely legacy snapshots where NO byYear map is present anywhere — that behaviour is unchanged.

## Test plan

- [ ] Load the site on the current production JSONs (post-traces release). Confirm the yellow banner does NOT appear on the landing.
- [ ] Open a contributor with mixed activity (e.g. a reviewer without opened PRs). Confirm no banner.
- [ ] Point the site at an intentionally legacy \`contributors_prs.json\` (from before the traces release). Confirm the banner still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)