### PR TITLE
fix(detail): make the detail-page topbar mobile-friendly

### DIFF
--- a/app/components/PeriodFilter.vue
+++ b/app/components/PeriodFilter.vue
@@ -54,7 +54,10 @@ function onKey(e: KeyboardEvent): void {
 
 <style scoped>
 .wof-period-filter { display: inline-flex; gap: 0.25rem; padding: 0.25rem; background: #ececf5; border-radius: 999px; }
-.wof-period-filter__btn { padding: 0.4rem 0.9rem; border: 0; border-radius: 999px; background: transparent; cursor: pointer; font: inherit; }
+.wof-period-filter__btn { padding: 0.4rem 0.75rem; border: 0; border-radius: 999px; background: transparent; cursor: pointer; font: inherit; white-space: nowrap; }
 .wof-period-filter__btn--active { background: #1d1d1b; color: #fff; }
 .wof-period-filter__btn:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+@media (min-width: 768px) {
+  .wof-period-filter__btn { padding: 0.4rem 0.9rem; }
+}
 </style>

--- a/app/components/PeriodFilter.vue
+++ b/app/components/PeriodFilter.vue
@@ -19,6 +19,11 @@ function select(idx: number): void {
   period.value = opt.value
 }
 
+function selectByKey(key: Period['kind']): void {
+  const opt = OPTIONS.find(o => o.key === key)
+  if (opt) period.value = opt.value
+}
+
 function onKey(e: KeyboardEvent): void {
   if (e.key === 'ArrowRight') {
     e.preventDefault()
@@ -32,32 +37,69 @@ function onKey(e: KeyboardEvent): void {
 </script>
 
 <template>
-  <div
-    class="wof-period-filter"
-    role="group"
-    aria-label="Period filter"
-  >
-    <button
-      v-for="(opt, idx) in OPTIONS"
-      :key="opt.key"
-      type="button"
-      :aria-pressed="opt.key === period.kind ? 'true' : 'false'"
-      class="wof-period-filter__btn"
-      :class="{ 'wof-period-filter__btn--active': opt.key === period.kind }"
-      @click="select(idx)"
-      @keydown="onKey($event)"
+  <div class="wof-period-filter">
+    <div
+      class="wof-period-filter__segmented"
+      role="group"
+      aria-label="Period filter"
     >
-      {{ opt.label }}
-    </button>
+      <button
+        v-for="(opt, idx) in OPTIONS"
+        :key="opt.key"
+        type="button"
+        :aria-pressed="opt.key === period.kind ? 'true' : 'false'"
+        class="wof-period-filter__btn"
+        :class="{ 'wof-period-filter__btn--active': opt.key === period.kind }"
+        @click="select(idx)"
+        @keydown="onKey($event)"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+    <select
+      class="wof-period-filter__select"
+      aria-label="Period filter"
+      :value="period.kind"
+      @change="selectByKey(($event.target as HTMLSelectElement).value as Period['kind'])"
+    >
+      <option
+        v-for="opt in OPTIONS"
+        :key="opt.key"
+        :value="opt.key"
+      >
+        {{ opt.label }}
+      </option>
+    </select>
   </div>
 </template>
 
 <style scoped>
-.wof-period-filter { display: inline-flex; gap: 0.25rem; padding: 0.25rem; background: #ececf5; border-radius: 999px; }
-.wof-period-filter__btn { padding: 0.4rem 0.75rem; border: 0; border-radius: 999px; background: transparent; cursor: pointer; font: inherit; white-space: nowrap; }
+.wof-period-filter { min-width: 0; }
+.wof-period-filter__segmented { display: none; }
+.wof-period-filter__select {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  padding: 0.4rem 2rem 0.4rem 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  background: #ececf5 url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%231d1d1b' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>") no-repeat right 0.75rem center;
+  font: inherit;
+  color: #1d1d1b;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wof-period-filter__select:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+
+@media (min-width: 768px) {
+  .wof-period-filter__segmented { display: inline-flex; gap: 0.25rem; padding: 0.25rem; background: #ececf5; border-radius: 999px; }
+  .wof-period-filter__select { display: none; }
+}
+.wof-period-filter__btn { padding: 0.4rem 0.9rem; border: 0; border-radius: 999px; background: transparent; cursor: pointer; font: inherit; white-space: nowrap; }
 .wof-period-filter__btn--active { background: #1d1d1b; color: #fff; }
 .wof-period-filter__btn:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
-@media (min-width: 768px) {
-  .wof-period-filter__btn { padding: 0.4rem 0.9rem; }
-}
 </style>

--- a/app/pages/company/[slug].vue
+++ b/app/pages/company/[slug].vue
@@ -58,7 +58,9 @@ useHead(() => ({
       >
         ← Back to all contributors
       </NuxtLink>
-      <PeriodFilter />
+      <div class="wof-detail-topbar__filter">
+        <PeriodFilter />
+      </div>
       <span class="wof-detail-topbar__spacer" />
     </div>
     <PeriodFallbackBanner v-if="isLegacyData && company" />
@@ -109,11 +111,11 @@ useHead(() => ({
 
 <style scoped>
 .wof-detail-topbar {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 0.75rem;
   background: #1d1d1b;
 }
 .wof-detail-back {
@@ -123,13 +125,43 @@ useHead(() => ({
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
-  justify-self: start;
+  white-space: nowrap;
+  align-self: start;
 }
 .wof-detail-back:hover {
   background: rgba(255, 255, 255, 0.18);
 }
+.wof-detail-topbar__filter {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.wof-detail-topbar__filter::-webkit-scrollbar {
+  display: none;
+}
 .wof-detail-topbar__spacer {
-  justify-self: end;
+  display: none;
+}
+@media (min-width: 768px) {
+  .wof-detail-topbar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .wof-detail-back {
+    align-self: auto;
+    justify-self: start;
+  }
+  .wof-detail-topbar__filter {
+    overflow: visible;
+    justify-self: center;
+  }
+  .wof-detail-topbar__spacer {
+    display: block;
+    justify-self: end;
+  }
 }
 .wof-detail-two-col {
   display: grid;

--- a/app/pages/company/[slug].vue
+++ b/app/pages/company/[slug].vue
@@ -55,8 +55,10 @@ useHead(() => ({
       <NuxtLink
         to="/"
         class="wof-detail-back"
+        aria-label="Back to all contributors"
       >
-        ← Back to all contributors
+        <span class="wof-detail-back__short">← Back</span>
+        <span class="wof-detail-back__long">← Back to all contributors</span>
       </NuxtLink>
       <div class="wof-detail-topbar__filter">
         <PeriodFilter />
@@ -112,8 +114,8 @@ useHead(() => ({
 <style scoped>
 .wof-detail-topbar {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem;
   background: #1d1d1b;
@@ -126,18 +128,18 @@ useHead(() => ({
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   white-space: nowrap;
-  align-self: start;
 }
 .wof-detail-back:hover {
   background: rgba(255, 255, 255, 0.18);
 }
-.wof-detail-topbar__filter {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+.wof-detail-back__long { display: none; }
+@media (min-width: 768px) {
+  .wof-detail-back__short { display: none; }
+  .wof-detail-back__long { display: inline; }
 }
-.wof-detail-topbar__filter::-webkit-scrollbar {
-  display: none;
+.wof-detail-topbar__filter {
+  min-width: 0;
+  flex-shrink: 1;
 }
 .wof-detail-topbar__spacer {
   display: none;
@@ -146,22 +148,12 @@ useHead(() => ({
   .wof-detail-topbar {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
-    align-items: center;
     gap: 1rem;
     padding: 1rem;
   }
-  .wof-detail-back {
-    align-self: auto;
-    justify-self: start;
-  }
-  .wof-detail-topbar__filter {
-    overflow: visible;
-    justify-self: center;
-  }
-  .wof-detail-topbar__spacer {
-    display: block;
-    justify-self: end;
-  }
+  .wof-detail-back { justify-self: start; }
+  .wof-detail-topbar__filter { justify-self: center; }
+  .wof-detail-topbar__spacer { display: block; justify-self: end; }
 }
 .wof-detail-two-col {
   display: grid;

--- a/app/pages/contributor/[login].vue
+++ b/app/pages/contributor/[login].vue
@@ -72,8 +72,10 @@ useHead(() => ({
       <NuxtLink
         to="/"
         class="wof-detail-back"
+        aria-label="Back to all contributors"
       >
-        ← Back to all contributors
+        <span class="wof-detail-back__short">← Back</span>
+        <span class="wof-detail-back__long">← Back to all contributors</span>
       </NuxtLink>
       <div class="wof-detail-topbar__filter">
         <PeriodFilter />
@@ -141,8 +143,8 @@ useHead(() => ({
 <style scoped>
 .wof-detail-topbar {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem;
   background: #1d1d1b;
@@ -155,18 +157,18 @@ useHead(() => ({
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   white-space: nowrap;
-  align-self: start;
 }
 .wof-detail-back:hover {
   background: rgba(255, 255, 255, 0.18);
 }
-.wof-detail-topbar__filter {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+.wof-detail-back__long { display: none; }
+@media (min-width: 768px) {
+  .wof-detail-back__short { display: none; }
+  .wof-detail-back__long { display: inline; }
 }
-.wof-detail-topbar__filter::-webkit-scrollbar {
-  display: none;
+.wof-detail-topbar__filter {
+  min-width: 0;
+  flex-shrink: 1;
 }
 .wof-detail-topbar__spacer {
   display: none;
@@ -175,22 +177,12 @@ useHead(() => ({
   .wof-detail-topbar {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
-    align-items: center;
     gap: 1rem;
     padding: 1rem;
   }
-  .wof-detail-back {
-    align-self: auto;
-    justify-self: start;
-  }
-  .wof-detail-topbar__filter {
-    overflow: visible;
-    justify-self: center;
-  }
-  .wof-detail-topbar__spacer {
-    display: block;
-    justify-self: end;
-  }
+  .wof-detail-back { justify-self: start; }
+  .wof-detail-topbar__filter { justify-self: center; }
+  .wof-detail-topbar__spacer { display: block; justify-self: end; }
 }
 .wof-detail-two-col {
   display: grid;

--- a/app/pages/contributor/[login].vue
+++ b/app/pages/contributor/[login].vue
@@ -75,7 +75,9 @@ useHead(() => ({
       >
         ← Back to all contributors
       </NuxtLink>
-      <PeriodFilter />
+      <div class="wof-detail-topbar__filter">
+        <PeriodFilter />
+      </div>
       <span class="wof-detail-topbar__spacer" />
     </div>
     <PeriodFallbackBanner v-if="isLegacyData && contributor" />
@@ -138,11 +140,11 @@ useHead(() => ({
 
 <style scoped>
 .wof-detail-topbar {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 0.75rem;
   background: #1d1d1b;
 }
 .wof-detail-back {
@@ -152,13 +154,43 @@ useHead(() => ({
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
-  justify-self: start;
+  white-space: nowrap;
+  align-self: start;
 }
 .wof-detail-back:hover {
   background: rgba(255, 255, 255, 0.18);
 }
+.wof-detail-topbar__filter {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.wof-detail-topbar__filter::-webkit-scrollbar {
+  display: none;
+}
 .wof-detail-topbar__spacer {
-  justify-self: end;
+  display: none;
+}
+@media (min-width: 768px) {
+  .wof-detail-topbar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .wof-detail-back {
+    align-self: auto;
+    justify-self: start;
+  }
+  .wof-detail-topbar__filter {
+    overflow: visible;
+    justify-self: center;
+  }
+  .wof-detail-topbar__spacer {
+    display: block;
+    justify-self: end;
+  }
 }
 .wof-detail-two-col {
   display: grid;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Reworks the dark topbar on `/contributor/:login` and `/company/:slug` so it stops breaking on mobile. On < 768 px the layout switches to a compact flex row with a shortened "← Back" link on the left and a native `<select>` for the period filter on the right — the OS picker replaces the horizontally-cramped four-pill segmented control that previously wrapped every label onto multiple lines and clipped "This year" off the edge. The desktop layout (segmented pills + full "Back to all contributors" label + 1fr auto 1fr grid) is preserved from 768 px up. Pills also get `white-space: nowrap` so their labels can never wrap inside a pill again. Aria-label on the shortened back link preserves the full text for assistive tech.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | 1. Open `/company/creabilis` (or any `/contributor/<login>`) on a ~390 px viewport. Expected: "← Back" pill on the left and "Since the beginning ▾" native dropdown on the right, both on a single line, no label wrapping, nothing clipped. 2. Tap the dropdown — the OS picker opens with the four options; picking "Last year" updates KPIs and charts. 3. Resize past 768 px — the four-pill segmented control and the full "← Back to all contributors" label reappear, layout identical to before this PR. 4. Screen reader: the mobile back link is announced as "Back to all contributors" (via `aria-label`), the segmented control and the `<select>` both expose `aria-label="Period filter"`.