### PR TITLE
feat(company): full detail parity + members list

### DIFF
--- a/app/components/detail/DetailKpiRow.vue
+++ b/app/components/detail/DetailKpiRow.vue
@@ -14,17 +14,18 @@ defineProps<{ vm: EntityDetailVM, yearsActive: number }>()
       <strong>{{ vm.kpis.mergedPr }}</strong>
       <span>Merged PRs</span>
     </div>
-    <!-- Opened PRs / Merge rate: contributors only. For companies, openedPr === mergedPr
-         (see useEntityDetail.ts) so the merge rate would always show 100%, misleading. -->
+    <!-- Opened PRs / Merge rate only make sense when we actually have opened-PR
+         data. Legacy scalar snapshots and edge-case entities (e.g. zero-activity
+         contributors) get these tiles hidden rather than showing "0% Merge rate". -->
     <div
-      v-if="vm.entityType === 'contributor'"
+      v-if="vm.kpis.openedPr > 0"
       class="wof-detail-kpi"
     >
       <strong>{{ vm.kpis.openedPr }}</strong>
       <span>Opened PRs</span>
     </div>
     <div
-      v-if="vm.entityType === 'contributor'"
+      v-if="vm.kpis.openedPr > 0"
       class="wof-detail-kpi"
     >
       <strong>{{ vm.kpis.mergeRate }}%</strong>

--- a/app/components/detail/DetailMembersList.vue
+++ b/app/components/detail/DetailMembersList.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import type { Contributor } from '@/types'
+
+defineProps<{
+  members: (Pick<Contributor, 'login' | 'name' | 'avatar_url'>)[]
+}>()
+</script>
+
+<template>
+  <div
+    id="section-members"
+    class="wof-detail-members"
+    data-detail-section
+  >
+    <h3 class="puik-h3">
+      Contributors ({{ members.length }})
+    </h3>
+    <ul class="wof-detail-members__grid">
+      <li
+        v-for="m in members"
+        :key="m.login"
+        class="wof-detail-members__item"
+      >
+        <NuxtLink
+          :to="`/contributor/${m.login.toLowerCase()}`"
+          class="wof-detail-members__link"
+          :aria-label="`View ${m.name || m.login}'s detail page`"
+        >
+          <img
+            v-if="m.avatar_url"
+            :src="m.avatar_url"
+            alt=""
+            class="wof-detail-members__avatar"
+          >
+          <div class="wof-detail-members__label">
+            <span class="wof-detail-members__name">{{ m.name || m.login }}</span>
+            <span
+              v-if="m.name"
+              class="wof-detail-members__handle"
+            >@{{ m.login }}</span>
+          </div>
+        </NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.wof-detail-members {
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+.wof-detail-members__grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+.wof-detail-members__link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease;
+}
+.wof-detail-members__link:hover {
+  background: #ececf5;
+}
+.wof-detail-members__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.wof-detail-members__label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.wof-detail-members__name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wof-detail-members__handle {
+  font-size: 0.85rem;
+  color: #5e5e5e;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/app/composables/useEntityDetail.ts
+++ b/app/composables/useEntityDetail.ts
@@ -50,11 +50,12 @@ export function buildEntityDetail(
     ? sumCounter(pairCounter(c.merged_pull_requests as number, c.merged_pull_requests_by_year), p, updatedYear)
     : sumCounter(pairCounter(c.mergedPullRequests as number, c.mergedPullRequestsByYear), p, updatedYear)
 
-  // Companies don't track opened PRs separately; consumers rendering
-  // mergeRate or prBreakdown.opened should suppress them when entityType==='company'
-  // (both would otherwise show as 100% / 0 for every company).
+  // A raw Company entity carries no opened-PR data, so openedPr falls to 0 and
+  // DetailKpiRow hides the merge-rate/opened tiles. For companies rendered
+  // through the aggregated-contributor path, openedPr comes through as a real
+  // number and both tiles show up.
   const openedPr = isCompany(entity)
-    ? mergedPr
+    ? 0
     : sumCounter(pairCounter(c.pullRequestsOpened as number, c.pullRequestsOpenedByYear), p, updatedYear)
 
   const reviews = sumCounter(pairCounter(c.reviews as number, c.reviewsByYear), p, updatedYear)
@@ -92,7 +93,10 @@ export function buildEntityDetail(
     },
     prBreakdown: {
       merged: mergedPr,
-      opened: Math.max(0, openedPr - mergedPr),
+      // openedPr is the TOTAL opened count; subtract merged to get "opened but
+      // not merged". Clamp to 0 when there's no data (openedPr = 0) so the
+      // donut renders a pure "merged" slice rather than negative-then-clamped.
+      opened: openedPr === 0 ? 0 : Math.max(0, openedPr - mergedPr),
     },
     repoRows,
     entityType: isCompany(entity) ? 'company' : 'contributor',
@@ -108,4 +112,84 @@ export function useEntityDetail(
   return computed<EntityDetailVM | null>(() =>
     entity.value ? buildEntityDetail(entity.value, period, updatedYear.value) : null,
   )
+}
+
+/**
+ * Aggregates a list of contributors into a synthetic Contributor whose counters
+ * are the sum of the members'. Used to render a company's detail page with the
+ * same rich KPI/chart set as an individual contributor.
+ *
+ * The company's `merged_pull_requests(_by_year)` scalars are ignored here in
+ * favour of the aggregate — traces already computes them from the same members,
+ * so the two match. Reviews / issues / opened PRs are only available at member
+ * level, so aggregation is the only way to surface them at company scope.
+ */
+export function aggregateContributors(
+  company: Company,
+  members: Contributor[],
+): Contributor {
+  const sumScalar = (key: 'mergedPullRequests' | 'pullRequestsOpened' | 'reviews' | 'issuesOpened' | 'contributions') =>
+    members.reduce((s, m) => s + (typeof m[key] === 'number' ? (m[key] as number) : 0), 0)
+
+  const sumByYear = (key: 'mergedPullRequestsByYear' | 'pullRequestsOpenedByYear' | 'reviewsByYear' | 'issuesOpenedByYear') => {
+    const result: Record<string, number> = {}
+    for (const m of members) {
+      const map = m[key]
+      if (!map) continue
+      for (const [year, n] of Object.entries(map)) {
+        result[year] = (result[year] ?? 0) + n
+      }
+    }
+    return result
+  }
+
+  const sumRepos = () => {
+    const result: Record<string, number> = {}
+    for (const m of members) {
+      for (const [repo, n] of Object.entries(m.repositories ?? {})) {
+        result[repo] = (result[repo] ?? 0) + (n as number)
+      }
+    }
+    return result
+  }
+
+  const sumReposByYear = () => {
+    const result: Record<string, Record<string, number>> = {}
+    for (const m of members) {
+      const map = m.repositoriesByYear
+      if (!map) continue
+      for (const [repo, years] of Object.entries(map)) {
+        result[repo] ??= {}
+        for (const [year, n] of Object.entries(years)) {
+          result[repo][year] = (result[repo][year] ?? 0) + n
+        }
+      }
+    }
+    return result
+  }
+
+  return {
+    login: company.slug ?? company.name,
+    id: 0,
+    name: company.name,
+    avatar_url: company.avatar_url,
+    html_url: company.html_url,
+    company: company.name,
+    blog: null,
+    location: null,
+    bio: null,
+    email_domain: null,
+    contributions: sumScalar('contributions'),
+    mergedPullRequests: sumScalar('mergedPullRequests'),
+    mergedPullRequestsByYear: sumByYear('mergedPullRequestsByYear'),
+    pullRequestsOpened: sumScalar('pullRequestsOpened'),
+    pullRequestsOpenedByYear: sumByYear('pullRequestsOpenedByYear'),
+    reviews: sumScalar('reviews'),
+    reviewsByYear: sumByYear('reviewsByYear'),
+    issuesOpened: sumScalar('issuesOpened'),
+    issuesOpenedByYear: sumByYear('issuesOpenedByYear'),
+    repositories: sumRepos(),
+    repositoriesByYear: sumReposByYear(),
+    categories: {},
+  }
 }

--- a/app/pages/company/[slug].vue
+++ b/app/pages/company/[slug].vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { computed, ref, watchEffect } from 'vue'
 import { usePeriod } from '@/composables/usePeriod'
-import { useEntityDetail } from '@/composables/useEntityDetail'
-import type { Company } from '@/types'
+import { aggregateContributors, useEntityDetail } from '@/composables/useEntityDetail'
+import type { Company, Contributor } from '@/types'
 
 const route = useRoute()
 const period = usePeriod()
 const company = ref<Company | null>(null)
+const contributorsData = ref<Record<string, Contributor>>({})
 const updatedYear = ref<number>(new Date().getFullYear())
 const loadError = ref<string | null>(null)
 
@@ -14,16 +15,26 @@ watchEffect(async () => {
   const slug = route.params.slug as string
   if (!slug) return
   try {
-    const res = await fetch('/topcompanies_prs.json')
-    if (!res.ok) throw new Error(String(res.status))
-    const data = await res.json()
-    if (data.updatedAt) updatedYear.value = new Date(data.updatedAt).getUTCFullYear()
-    // Case-insensitive slug match.
+    const [companiesRes, contributorsRes] = await Promise.all([
+      fetch('/topcompanies_prs.json'),
+      fetch('/contributors_prs.json'),
+    ])
+    if (!companiesRes.ok) throw new Error(String(companiesRes.status))
+    const companiesJson = await companiesRes.json()
+    if (companiesJson.updatedAt) updatedYear.value = new Date(companiesJson.updatedAt).getUTCFullYear()
+
     const lower = slug.toLowerCase()
-    const c = (data.companies ?? []).find((cc: Company) => cc.slug?.toLowerCase() === lower)
+    const c = (companiesJson.companies ?? []).find((cc: Company) => cc.slug?.toLowerCase() === lower)
     company.value = c ?? null
-    if (!company.value) loadError.value = `Company "${slug}" not found.`
-    else loadError.value = null
+    if (!company.value) {
+      loadError.value = `Company "${slug}" not found.`
+      return
+    }
+    loadError.value = null
+
+    if (contributorsRes.ok) {
+      contributorsData.value = await contributorsRes.json()
+    }
   }
   catch (e) {
     loadError.value = 'Failed to load data.'
@@ -31,8 +42,37 @@ watchEffect(async () => {
   }
 })
 
-const vm = useEntityDetail(company, period, updatedYear)
-const yearsActive = computed(() => Object.keys(vm.value?.yearlySeries.mergedPullRequests ?? {}).length)
+// Build a synthetic Contributor from the company's member logins so the whole
+// contributor-detail toolkit (KPIs, charts, tabs, repos table) applies to a
+// company aggregate without any per-entity forking downstream.
+const members = computed<Contributor[]>(() => {
+  const c = company.value
+  if (!c?.contributors) return []
+  return c.contributors
+    .map(login => contributorsData.value[login])
+    .filter((m): m is Contributor => m != null && typeof m === 'object' && 'login' in m)
+})
+
+const aggregated = computed<Contributor | null>(() =>
+  company.value && members.value.length ? aggregateContributors(company.value, members.value) : null,
+)
+
+const vm = useEntityDetail(aggregated, period, updatedYear)
+
+// Preserve the company entity type + members list downstream — the
+// aggregate is a Contributor shape so useEntityDetail defaults to
+// entityType='contributor'; overwrite so the KPI row + members section render
+// their company-specific bits.
+const companyVm = computed(() => {
+  if (!vm.value || !company.value) return null
+  return {
+    ...vm.value,
+    entityType: 'company' as const,
+    members: company.value.contributors ?? [],
+  }
+})
+
+const yearsActive = computed(() => Object.keys(companyVm.value?.yearlySeries.mergedPullRequests ?? {}).length)
 const isLegacyData = computed(() => {
   const c = company.value
   if (!c) return false
@@ -67,35 +107,46 @@ useHead(() => ({
     </div>
     <PeriodFallbackBanner v-if="isLegacyData && company" />
 
-    <DetailPageLayout v-if="vm && company">
+    <DetailPageLayout v-if="companyVm && company">
       <template #sidebar>
         <DetailSidebar
           :avatar-url="company.avatar_url"
           :title="company.name"
-          :subtitle="`${vm.members?.length ?? 0} contributors`"
+          :subtitle="`${companyVm.members?.length ?? 0} contributors`"
+          :infos="company.html_url
+            ? [{ icon: 'link', label: 'GitHub', value: company.html_url, href: company.html_url }]
+            : []"
           :sections="[
             { id: 'section-kpis', label: 'Overview' },
             { id: 'section-yearly', label: 'Contributions per year' },
             { id: 'section-donut', label: 'PR breakdown' },
+            { id: 'section-top-repos', label: 'Top repositories' },
+            { id: 'section-year-detail', label: 'Year drilldown' },
+            { id: 'section-repos-table', label: 'All repos' },
+            { id: 'section-members', label: 'Contributors' },
           ]"
         />
       </template>
       <template #main>
         <DetailKpiRow
-          :vm="vm"
+          :vm="companyVm"
           :years-active="yearsActive"
         />
         <div class="wof-detail-two-col">
           <DetailYearlyChart
-            :series="vm.yearlySeries"
+            :series="companyVm.yearlySeries"
             :period="period"
             :updated-year="updatedYear"
           />
           <DetailPrDonut
-            :merged="vm.prBreakdown.merged"
-            :other="vm.prBreakdown.opened"
+            :merged="companyVm.prBreakdown.merged"
+            :other="companyVm.prBreakdown.opened"
           />
         </div>
+        <DetailTopReposChart :top-repos="companyVm.topRepos" />
+        <DetailYearTabs :series="companyVm.yearlySeries" />
+        <DetailReposTable :rows="companyVm.repoRows" />
+        <DetailMembersList :members="members" />
       </template>
     </DetailPageLayout>
 


### PR DESCRIPTION
## Summary

Follow-up to #241 (merged). The company detail page now renders the same rich toolkit as a contributor — plus a new Contributors section listing every member with a direct link to their \`/contributor/:login\` page.

## What ships

**Company page now has, in addition to what it already had (Overview KPIs + yearly chart + PR breakdown):**
- Top repositories bar chart
- Year drilldown tabs
- Exhaustive All-repositories table (sortable / searchable)
- **Contributors section** — responsive grid of member cards, each linking to the contributor detail page

## Implementation

- \`aggregateContributors()\` (new, in \`useEntityDetail.ts\`) builds a synthetic \`Contributor\` from a company's \`contributors[]\`. Scalars are summed, \`*ByYear\` maps are merged year-by-year, \`repositoriesByYear\` merges repo-by-repo and year-by-year. No per-entity forking downstream — the whole existing contributor toolkit just accepts the aggregate as input.
- \`pages/company/[slug].vue\` now fetches \`contributors_prs.json\` alongside \`topcompanies_prs.json\`, aggregates the members, and renders the full \`DetailPageLayout\`. A \`companyVm\` override reasserts \`entityType='company'\` and threads the raw \`contributors[]\` list through so \`DetailKpiRow\` shows the Contributors tile and \`DetailMembersList\` knows its size.
- \`DetailMembersList.vue\` (new): responsive grid of member cards linking to each contributor's detail page.
- \`DetailKpiRow\`: the Opened PRs / Merge rate tiles now gate on \`vm.kpis.openedPr > 0\` instead of \`entityType === 'contributor'\`, so a company aggregate with real opened-PR data shows them and a raw \`Company\` (without member aggregation) hides them cleanly.
- \`useEntityDetail\`: raw \`Company\` entity now yields \`openedPr = 0\` instead of copying \`mergedPr\`, keeping the KPI gating honest — the mergeRate=100% / opened=0 artefact was misleading.

## Data caveat

The reviews / issues / opened-PRs KPIs on a company are only populated when the underlying \`contributors_prs.json\` carries those counters (traces \`topstats\` step). Snapshots produced without \`traces:generate:topstats\` (no GH token available) will simply hide those tiles.

## Test plan

- [ ] \`node_modules/.bin/vitest --run\` — 42/42 passing.
- [ ] \`node_modules/.bin/eslint .\` clean.
- [ ] Visit a company detail page (e.g. \`/company/prestashop\`). Confirm the sidebar lists all seven sections, the KPI row surfaces the Contributors tile plus any opened-PR data, and the Contributors section renders a card per member with a working link.
- [ ] Click a member card — lands on \`/contributor/:login\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)