### PR TITLE
fix(period): filter yearly chart by period + fix SSR hydration of active tab

### DIFF
--- a/app/components/detail/DetailYearlyChart.vue
+++ b/app/components/detail/DetailYearlyChart.vue
@@ -16,25 +16,21 @@ const props = defineProps<{
   updatedYear: number
 }>()
 
+function inPeriod(y: number): boolean {
+  if (props.period.kind === 'sinceStart') return true
+  if (props.period.kind === 'thisYear') return y === props.updatedYear
+  if (props.period.kind === 'lastYear') return y === props.updatedYear - 1
+  return y >= props.updatedYear - props.period.n + 1 && y <= props.updatedYear
+}
+
 const years = computed(() => {
   const set = new Set<string>([
     ...Object.keys(props.series.mergedPullRequests),
     ...Object.keys(props.series.reviews),
     ...Object.keys(props.series.issuesOpened),
   ])
-  return [...set].sort()
+  return [...set].filter(y => inPeriod(Number(y))).sort()
 })
-
-function isActive(year: string): boolean {
-  const y = Number(year)
-  if (props.period.kind === 'sinceStart') return true
-  if (props.period.kind === 'lastYear') return y === props.updatedYear
-  return y >= props.updatedYear - props.period.n + 1 && y <= props.updatedYear
-}
-
-function color(base: string, active: boolean): string {
-  return active ? base : base + '55'
-}
 
 const data = computed(() => ({
   labels: years.value,
@@ -42,17 +38,17 @@ const data = computed(() => ({
     {
       label: 'Merged PRs',
       data: years.value.map(y => props.series.mergedPullRequests[y] ?? 0),
-      backgroundColor: years.value.map(y => color('#6366f1', isActive(y))),
+      backgroundColor: '#6366f1',
     },
     {
       label: 'Reviews',
       data: years.value.map(y => props.series.reviews[y] ?? 0),
-      backgroundColor: years.value.map(y => color('#22c55e', isActive(y))),
+      backgroundColor: '#22c55e',
     },
     {
       label: 'Issues',
       data: years.value.map(y => props.series.issuesOpened[y] ?? 0),
-      backgroundColor: years.value.map(y => color('#f59e0b', isActive(y))),
+      backgroundColor: '#f59e0b',
     },
   ],
 }))

--- a/app/composables/usePeriod.ts
+++ b/app/composables/usePeriod.ts
@@ -1,4 +1,4 @@
-import { inject, provide, ref, watch, type InjectionKey, type Ref } from 'vue'
+import { inject, onMounted, provide, ref, watch, type InjectionKey, type Ref } from 'vue'
 import type { Period } from '@/types'
 
 export const PERIOD_KEY: InjectionKey<Ref<Period>> = Symbol('period')
@@ -26,11 +26,14 @@ export function parsePeriodParam(raw: string | null): Period {
 }
 
 export function providePeriod(): Ref<Period> {
-  const initial = typeof window !== 'undefined'
-    ? parsePeriodParam(new URL(window.location.href).searchParams.get('period'))
-    : DEFAULT
+  // Start with DEFAULT on both server and client so hydration classes match.
+  // The URL query param is applied post-mount to avoid Vue's hydration mismatch,
+  // which for class attributes freezes the SSR value in place.
+  const period = ref<Period>(DEFAULT)
 
-  const period = ref<Period>(initial)
+  onMounted(() => {
+    period.value = parsePeriodParam(new URL(window.location.href).searchParams.get('period'))
+  })
 
   if (typeof window !== 'undefined') {
     watch(period, (next) => {


### PR DESCRIPTION
## Summary

Two related fixes for the contributor/company detail pages when a period filter is active.

- **Yearly chart now filters years by period.** `DetailYearlyChart` was showing every year in the dataset and just dimming the ones outside the selected window. That produced a jarring mismatch — for a contributor active only in 2013-2016, viewing "Last 3 years" showed KPIs at 0 next to a 300-tall Merged PRs bar. The chart now drops out-of-period years from labels entirely, so it renders empty when the window has no data. The PR breakdown donut was already period-filtered.
- **Period filter tab now reflects `?period=…` on direct URL load.** `providePeriod()` read the URL during setup, but under SSR `window` is undefined so the initial value fell back to \`sinceStart\`. On the client, the ref did get the URL value, but Vue's hydration mismatch handling freezes `class` attributes — the wrong tab stayed highlighted. Fix: use the same DEFAULT on both server and client so hydration matches, then apply the URL param in `onMounted`.

## Test plan

- [x] `vitest run` — 42/42 pass
- [x] eslint clean on both files
- [x] Manual: land on `/contributor/<login>?period=3y` for a contributor with only pre-2023 activity → "Last 3 years" tab is active, KPIs are 0, both charts render empty.
- [x] Switch periods via the tabs → URL and charts update reactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)