### PR TITLE
fix(a11y/seo): use entity name as external link text and aria-label

### DIFF
--- a/app/components/sections/sub-sections/TopCompaniesView.vue
+++ b/app/components/sections/sub-sections/TopCompaniesView.vue
@@ -128,15 +128,17 @@ const decoratedItems = computed(() =>
         <a
           :href="item.html_url as string"
           target="_blank"
-          aria-label="Open company page in a new tab"
+          :aria-label="`Open ${item.name} page in a new tab`"
           rel="noopener noreferrer"
         >
           <puik-button
             variant="text"
             force-legacy-text-variant
             right-icon="open_in_new"
-            aria-label="Open company page in a new tab"
-          />
+            :aria-label="`Open ${item.name} page in a new tab`"
+          >
+            <span class="sr-only">{{ item.name }}</span>
+          </puik-button>
         </a>
         <NuxtLink
           v-if="item.slug"

--- a/app/components/sections/sub-sections/TopContributorsView.vue
+++ b/app/components/sections/sub-sections/TopContributorsView.vue
@@ -133,15 +133,17 @@ const { currentContributor, isModalOpen, openModal, closeModal } = useContributo
         <a
           :href="item.html_url as string"
           target="_blank"
-          aria-label="Open GitHub profile in a new tab"
+          :aria-label="`Open ${item.login} GitHub profile in a new tab`"
           rel="noopener noreferrer"
         >
           <puik-button
             variant="text"
             force-legacy-text-variant
             right-icon="open_in_new"
-            aria-label="Open GitHub profile in a new tab"
-          />
+            :aria-label="`Open ${item.login} GitHub profile in a new tab`"
+          >
+            <span class="sr-only">{{ item.login }}</span>
+          </puik-button>
         </a>
         <NuxtLink
           :to="`/contributor/${(item.login as string).toLowerCase()}`"

--- a/app/components/sections/sub-sections/TopRankingView.vue
+++ b/app/components/sections/sub-sections/TopRankingView.vue
@@ -105,15 +105,17 @@ const fullWidth = ref(true)
         <a
           :href="item.html_url"
           target="_blank"
-          aria-label="Open GitHub profile in a new tab"
+          :aria-label="`Open ${item.login || item.name} GitHub profile in a new tab`"
           rel="noopener noreferrer"
         >
           <puik-button
             variant="text"
             force-legacy-text-variant
             right-icon="open_in_new"
-            aria-label="Open GitHub profile in a new tab"
-          />
+            :aria-label="`Open ${item.login || item.name} GitHub profile in a new tab`"
+          >
+            <span class="sr-only">{{ item.login || item.name }}</span>
+          </puik-button>
         </a>
         <NuxtLink
           v-if="item.login"


### PR DESCRIPTION
## Summary

The external-link icon buttons on the landing ranking tables currently expose `open_in_new` as their accessible name and use a generic `Open ... in a new tab` aria-label. This hurts both SEO (weak anchor text) and screen-reader clarity (every row sounds identical).

This PR replaces the static values with the entity name/login:

- **TopCompaniesView** — anchor text and aria-label now use `item.name`
- **TopContributorsView** — anchor text and aria-label now use `item.login`
- **TopRankingView** — anchor text and aria-label now use `item.login || item.name` (fallback for company entries)

The visible UI is unchanged: the entity name is injected via `<span class="sr-only">` inside the `puik-button`, so search engines and assistive tech get a meaningful anchor while the layout stays identical.

Reported by @Jonathan Danse.

## Test plan

- [ ] `pnpm dev` and inspect a company row on the landing: the `<a>` should have `aria-label="Open <CompanyName> page in a new tab"` and contain a visually-hidden span with the name
- [ ] Same check on a top-contributor and a ranking row (with an `item.login`)
- [ ] Screen reader announces the entity name instead of "open_in_new"
- [ ] No visual regression on the action-buttons row

🤖 Generated with [Claude Code](https://claude.com/claude-code)