### PR TITLE
Add link to the website in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Top Contributors
 
+[contributors.prestashop-project.org](https://contributors.prestashop-project.org/)
+
 A website to thank every PrestaShop contributors.
 
 This Nuxt 4 application showcasing PrestaShop's top contributors, companies, and community members who actively contribute to the PrestaShop ecosystem.


### PR DESCRIPTION
this is great that the link in the right column of the Github UI, but in term of UX, this is also very important that this link is also in the actual readme file. Because someone forking, or someone just opening the readme directly will not have the link and will search for the website.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix / improvement / new feature / refactor
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Indicate how to verify that this change works as expected.
