### PR TITLE
fix(company): split GitHub and Website links on the sidebar

### DIFF
--- a/app/pages/company/[slug].vue
+++ b/app/pages/company/[slug].vue
@@ -124,9 +124,10 @@ useHead(() => ({
           :avatar-url="company.avatar_url"
           :title="company.name"
           :subtitle="`${memberCount} contributors`"
-          :infos="company.html_url
-            ? [{ icon: 'link', label: 'GitHub', value: company.html_url, href: company.html_url }]
-            : []"
+          :infos="[
+            ...(company.github_url ? [{ icon: 'link', label: 'GitHub', value: company.github_url, href: company.github_url }] : []),
+            ...(company.html_url ? [{ icon: 'desktop_mac', label: 'Website', value: company.html_url, href: company.html_url }] : []),
+          ]"
           :sections="[
             { id: 'section-kpis', label: 'Overview' },
             { id: 'section-yearly', label: 'Contributions per year' },

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -15,6 +15,7 @@ export interface Company {
   pull_requests_percent: number
   avatar_url: string
   html_url: string
+  github_url?: string
   login?: string
   slug?: string
   // Derived at PR-attribution time (union of authors whose merged PRs were


### PR DESCRIPTION
## Summary
- Company `html_url` is the company **website**, not a GitHub URL — the sidebar was mislabeling it "GitHub".
- Render two distinct entries: optional GitHub (from the new `github_url` field) and Website (from `html_url`, with the same `desktop_mac` icon the contributor sidebar uses).
- Add `github_url?: string` to the `Company` type.

## Context
Consumes the `github_url` field added upstream in PrestaShop/traces#241. Companies without `github_url` in the source will only show the Website line.

## Test plan
- [ ] Visit `/company/prestaedit` — sidebar shows GitHub → github.com/PrestaEdit and Website → prestaedit.com.
- [ ] Visit a company without `github_url` — only the Website line appears.
- [ ] Contributor detail sidebar unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)