### PR TITLE
feat(card): expose share snippet on contributor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This Nuxt 4 application showcasing PrestaShop's top contributors, companies, and
 - **Wall of Fame**: Comprehensive tables featuring all contributors and companies
 - **New Contributors**: Highlight recent additions to the contributor community
 - **Responsive Design**: Built with Tailwind CSS and PUIK Components for a modern, mobile-friendly experience
+- **Contributor Cards**: Each contributor has an embeddable SVG card at `/card/<login>.svg` — drop it into a GitHub profile README with `![](https://contributors.prestashop-project.org/card/<login>.svg)`. Grab the ready-made snippet from the "Share your card" section of each contributor page.
 
 ## Tech Stack
 

--- a/app/components/detail/DetailShareCard.vue
+++ b/app/components/detail/DetailShareCard.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = defineProps<{ login: string }>()
+
+// Absolute URL so the snippet works when pasted anywhere. Falls back to the
+// production origin during SSR (import.meta.client guard keeps window off the
+// server path).
+const origin = computed(() =>
+  import.meta.client ? window.location.origin : 'https://contributors.prestashop-project.org',
+)
+const cardUrl = computed(() => `${origin.value}/card/${props.login}.svg`)
+const markdown = computed(() => `[![PrestaShop Top Contributor](${cardUrl.value})](${origin.value}/contributor/${props.login})`)
+
+const copied = ref<'url' | 'md' | null>(null)
+const copy = async (kind: 'url' | 'md', text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    copied.value = kind
+    setTimeout(() => { if (copied.value === kind) copied.value = null }, 1500)
+  }
+  catch { /* clipboard unavailable — user can still select the text */ }
+}
+</script>
+
+<template>
+  <section
+    id="section-share"
+    class="wof-detail-share"
+    data-detail-section
+  >
+    <h2 class="wof-detail-share__title">
+      Share your card
+    </h2>
+    <p class="wof-detail-share__lede">
+      Embed this card in your GitHub profile README or anywhere else.
+    </p>
+
+    <div class="wof-detail-share__preview">
+      <img
+        :src="cardUrl"
+        :alt="`PrestaShop Top Contributor card for ${login}`"
+        loading="lazy"
+      >
+    </div>
+
+    <div class="wof-detail-share__field">
+      <label>Markdown</label>
+      <div class="wof-detail-share__row">
+        <input
+          :value="markdown"
+          readonly
+          @focus="($event.target as HTMLInputElement).select()"
+        >
+        <button
+          type="button"
+          @click="copy('md', markdown)"
+        >
+          {{ copied === 'md' ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="wof-detail-share__field">
+      <label>URL</label>
+      <div class="wof-detail-share__row">
+        <input
+          :value="cardUrl"
+          readonly
+          @focus="($event.target as HTMLInputElement).select()"
+        >
+        <button
+          type="button"
+          @click="copy('url', cardUrl)"
+        >
+          {{ copied === 'url' ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.wof-detail-share {
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.wof-detail-share__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #1d1d1b;
+}
+.wof-detail-share__lede {
+  margin: 0;
+  color: #5e5e5e;
+  font-size: 0.9rem;
+}
+.wof-detail-share__preview {
+  background: #f4f4f8;
+  border-radius: 0.4rem;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: center;
+}
+.wof-detail-share__preview img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+.wof-detail-share__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.wof-detail-share__field label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #5e5e5e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.wof-detail-share__row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.wof-detail-share__row input {
+  flex: 1;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #dddddd;
+  border-radius: 0.35rem;
+  background: #f7f7f7;
+  color: #1d1d1b;
+}
+.wof-detail-share__row button {
+  flex-shrink: 0;
+  font-weight: 600;
+  padding: 0.55rem 1rem;
+  border: 0;
+  border-radius: 0.35rem;
+  background: #7b4fac;
+  color: #fff;
+  cursor: pointer;
+}
+.wof-detail-share__row button:hover {
+  background: #6a4194;
+}
+</style>

--- a/app/components/detail/DetailShareCard.vue
+++ b/app/components/detail/DetailShareCard.vue
@@ -17,7 +17,9 @@ const copy = async (kind: 'url' | 'md', text: string) => {
   try {
     await navigator.clipboard.writeText(text)
     copied.value = kind
-    setTimeout(() => { if (copied.value === kind) copied.value = null }, 1500)
+    setTimeout(() => {
+      if (copied.value === kind) copied.value = null
+    }, 1500)
   }
   catch { /* clipboard unavailable — user can still select the text */ }
 }

--- a/app/pages/contributor/[login].vue
+++ b/app/pages/contributor/[login].vue
@@ -103,6 +103,7 @@ useHead(() => ({
             { id: 'section-top-repos', label: 'Top repositories' },
             { id: 'section-year-detail', label: 'Year drilldown' },
             { id: 'section-repos-table', label: 'All repos' },
+            { id: 'section-share', label: 'Share your card' },
           ]"
         />
       </template>
@@ -125,6 +126,7 @@ useHead(() => ({
         <DetailTopReposChart :top-repos="vm.topRepos" />
         <DetailYearTabs :series="vm.yearlySeries" />
         <DetailReposTable :rows="vm.repoRows" />
+        <DetailShareCard :login="contributor.login" />
       </template>
     </DetailPageLayout>
 


### PR DESCRIPTION
Follow-up to #254 — makes the contributor SVG card discoverable and one-click embeddable.

## Summary
- Adds a **Share your card** section at the bottom of every contributor detail page: live preview of the SVG card + two read-only inputs with copy buttons (Markdown snippet ready for a GitHub README, and the raw URL).
- Registers the new section in the sidebar jump-nav.
- Adds a README bullet under **Features** so the capability is discoverable outside the site too.

## Test plan
- [x] `nuxt generate` builds without new errors; static contributor page includes the new section markup and inputs.
- [x] Sidebar jump-nav shows the new "Share your card" entry and anchors to `#section-share`.
- [ ] On the deployed site, verify the copy buttons write to clipboard and the preview `<img>` resolves against `contributors.prestashop-project.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)