### PR TITLE
fix(card): defensive indexBy against ranking items missing login

### DIFF
--- a/server/routes/card/[login].get.ts
+++ b/server/routes/card/[login].get.ts
@@ -32,7 +32,13 @@ const readRanking = (file: string) => {
 
 const indexBy = (r: Ranking | null, field: 'rank' | 'count') => {
   const m = new Map<string, number>()
-  for (const it of r?.items ?? []) m.set(it.login.toLowerCase(), it[field])
+  const items = Array.isArray(r?.items) ? r.items : []
+  for (const it of items) {
+    // Production ranking files occasionally carry summary/entries lacking a
+    // login (e.g. aggregate rows). Skip them rather than 500'ing the card.
+    if (!it || typeof it.login !== 'string' || !it.login) continue
+    m.set(it.login.toLowerCase(), it[field])
+  }
   return m
 }
 


### PR DESCRIPTION
## Summary
Scheduled build on \`develop\` (run [30611215911](https://github.com/PrestaShop/TopContributors/actions/runs/30611215911/job/91094174202)) crashed with 500 on every \`/card/*.svg\` because \`top_pullrequests.json\` in production carries at least one item without a \`login\` string, and \`indexBy\` called \`it.login.toLowerCase()\` unconditionally.

Change: skip malformed items (missing \`login\`) rather than 500'ing the card. Also guard against \`r.items\` being anything other than an array.

## Test plan
- [x] Reproduce failure mode locally by seeding a ranking file with one \`{}\` entry — pre-fix 500s, post-fix produces the card with rank/count blanks.
- [ ] Confirm next scheduled build on \`develop\` succeeds and prerenders \`/card/*.svg\` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)